### PR TITLE
Add draggable card prototype

### DIFF
--- a/CharacterCard.tscn
+++ b/CharacterCard.tscn
@@ -50,3 +50,6 @@ offset_top = 40.0
 offset_right = 125.0
 offset_bottom = 140.0
 stretch_mode = 5
+
+[node name="PopupMenu" type="PopupMenu" parent="."]
+

--- a/board.gd
+++ b/board.gd
@@ -5,11 +5,18 @@ const CharacterCard = preload("res://CharacterCard.tscn")
 var cards = []
 var connections = []
 var selected_card = null
+var rename_target = null
+
+@onready var rename_dialog: AcceptDialog = $RenameDialog
+@onready var rename_line_edit: LineEdit = $RenameDialog/LineEdit
 
 func _ready():
-	# Make board fill screen
-	anchor_right = 1.0
-	anchor_bottom = 1.0
+        # Make board fill screen
+        anchor_right = 1.0
+        anchor_bottom = 1.0
+
+        rename_dialog.get_ok_button().text = "Rename"
+        rename_dialog.connect("confirmed", _on_rename_confirmed)
 	
 	# Create cards
 	create_character_card("Elias Varn", Vector2(100, 100))
@@ -21,11 +28,13 @@ func _ready():
 func create_character_card(character_name: String, pos: Vector2):
 	var card = CharacterCard.instantiate()
 	add_child(card)
-	card.position = pos
-	card.set_character(character_name, cards.size())
-	card.card_clicked.connect(_on_card_clicked)
-	card.card_released.connect(_on_card_released)
-	cards.append(card)
+        card.position = pos
+        card.set_character(character_name, cards.size())
+        card.card_clicked.connect(_on_card_clicked)
+        card.card_released.connect(_on_card_released)
+        card.remove_connections.connect(_on_remove_connections)
+        card.rename_requested.connect(_on_rename_requested)
+        cards.append(card)
 
 func _on_card_clicked(card):
 	if selected_card and selected_card != card:
@@ -82,7 +91,27 @@ func _update_line_position(line: ColorRect, from_card, to_card):
 	line.position += offset
 
 func _process(_delta):
-	# Update all line positions when cards move
-	for conn in connections:
-		if is_instance_valid(conn.from) and is_instance_valid(conn.to):
-			_update_line_position(conn.line, conn.from, conn.to)
+        # Update all line positions when cards move
+        for conn in connections:
+                if is_instance_valid(conn.from) and is_instance_valid(conn.to):
+                        _update_line_position(conn.line, conn.from, conn.to)
+
+func _on_remove_connections(card):
+        var to_remove = []
+        for conn in connections:
+                if conn.from == card or conn.to == card:
+                        if is_instance_valid(conn.line):
+                                conn.line.queue_free()
+                        to_remove.append(conn)
+        for rem in to_remove:
+                connections.erase(rem)
+
+func _on_rename_requested(card):
+        rename_target = card
+        rename_line_edit.text = card.character_name
+        rename_dialog.popup_centered(Vector2(200, 80))
+
+func _on_rename_confirmed():
+        if rename_target:
+                rename_target.set_character(rename_line_edit.text, rename_target.character_id)
+                rename_target = null

--- a/board.tscn
+++ b/board.tscn
@@ -15,3 +15,11 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.168627, 0.168627, 0.168627, 1)
+
+[node name="RenameDialog" type="AcceptDialog" parent="."]
+visible = false
+
+[node name="LineEdit" type="LineEdit" parent="RenameDialog"]
+offset_left = 10.0
+offset_top = 10.0
+size_flags_horizontal = 3

--- a/character_card.gd
+++ b/character_card.gd
@@ -9,12 +9,19 @@ var character_id = 0
 
 signal card_clicked(card)
 signal card_released(card)
+signal remove_connections(card)
+signal rename_requested(card)
 
 func _ready():
-	mouse_filter = Control.MOUSE_FILTER_PASS
-	gui_input.connect(_on_gui_input)
-	custom_minimum_size = Vector2(150, 200)  # Ensure minimum size
-	size = Vector2(150, 200)  # Set actual size
+        mouse_filter = Control.MOUSE_FILTER_PASS
+        gui_input.connect(_on_gui_input)
+        custom_minimum_size = Vector2(150, 200)  # Ensure minimum size
+        size = Vector2(150, 200)  # Set actual size
+        var pm = $PopupMenu
+        pm.add_item("Inspect", 0)
+        pm.add_item("Rename", 1)
+        pm.add_item("Remove Connections", 2)
+        pm.id_pressed.connect(_on_popup_menu_id_pressed)
 
 func _draw():
 	# Draw our own background if Panel isn't working
@@ -50,4 +57,15 @@ func set_character(name: String, id: int):
 	$CharacterName.text = name
 
 func _show_context_menu():
-	print("Right clicked on: ", character_name)
+        var pm = $PopupMenu
+        pm.position = get_local_mouse_position()
+        pm.popup()
+
+func _on_popup_menu_id_pressed(id: int):
+        match id:
+                0:
+                        print("Inspect ", character_name)
+                1:
+                        emit_signal("rename_requested", self)
+                2:
+                        emit_signal("remove_connections", self)

--- a/main.tscn
+++ b/main.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://crskf13yea2cp"]
 
-[node name="Label" type="Label"]
-offset_right = 40.0
-offset_bottom = 23.0
-text = "Silent Ashes - Test"
+[ext_resource type="PackedScene" path="res://board.tscn" id="1_b4y9s"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Board" parent="." instance=ExtResource("1_b4y9s")]

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Silent_Ashes"
-run/main_scene="uid://bn2dogmuljg8i"
+run/main_scene="uid://crskf13yea2cp"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
## Summary
- add PopupMenu to character card for context actions
- allow connections to be removed or cards renamed
- add rename dialog in board scene
- load board as main scene

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c049f5cb083298bfab8d0a82d27d4