### PR TITLE
Add portrait selection

### DIFF
--- a/board.gd
+++ b/board.gd
@@ -6,9 +6,11 @@ var cards = []
 var connections = []
 var selected_card = null
 var rename_target = null
+var portrait_target = null
 
 @onready var rename_dialog: AcceptDialog = $RenameDialog
 @onready var rename_line_edit: LineEdit = $RenameDialog/LineEdit
+@onready var portrait_file_dialog: FileDialog = $PortraitFileDialog
 
 func _ready():
 	# Make board fill screen
@@ -17,7 +19,7 @@ func _ready():
 	
 	rename_dialog.get_ok_button().text = "Rename"
 	rename_dialog.connect("confirmed", _on_rename_confirmed)
-	
+	portrait_file_dialog.connect("file_selected", _on_portrait_file_selected)
 	# Create cards
 	create_character_card("Elias Varn", Vector2(100, 100))
 	create_character_card("Carina Bel", Vector2(300, 100))
@@ -34,6 +36,7 @@ func create_character_card(character_name: String, pos: Vector2):
 	card.card_released.connect(_on_card_released)
 	card.remove_connections.connect(_on_remove_connections)
 	card.rename_requested.connect(_on_rename_requested)
+        card.request_portrait.connect(_on_request_portrait)
 	cards.append(card)
 
 func _on_card_clicked(card):
@@ -115,3 +118,13 @@ func _on_rename_confirmed():
 	if rename_target:
 		rename_target.set_character(rename_line_edit.text, rename_target.character_id)
 		rename_target = null
+
+func _on_request_portrait(card):
+	portrait_target = card
+	portrait_file_dialog.popup_centered()
+
+func _on_portrait_file_selected(path):
+	if portrait_target:
+		var tex = load(path)
+		portrait_target.set_portrait(tex)
+		portrait_target = null

--- a/board.tscn
+++ b/board.tscn
@@ -23,3 +23,6 @@ visible = false
 offset_left = 10.0
 offset_top = 10.0
 size_flags_horizontal = 3
+
+[node name="PortraitFileDialog" type="FileDialog" parent="."]
+filters = PackedStringArray("*.png", "*.jpg")

--- a/character_card.gd
+++ b/character_card.gd
@@ -11,6 +11,7 @@ signal card_clicked(card)
 signal card_released(card)
 signal remove_connections(card)
 signal rename_requested(card)
+signal request_portrait(card)
 
 func _ready():
 	mouse_filter = Control.MOUSE_FILTER_PASS
@@ -21,6 +22,7 @@ func _ready():
 	pm.add_item("Inspect", 0)
 	pm.add_item("Rename", 1)
 	pm.add_item("Remove Connections", 2)
+        pm.add_item("Set Portrait", 3)
 	pm.id_pressed.connect(_on_popup_menu_id_pressed)
 
 func _draw():
@@ -56,6 +58,8 @@ func set_character(name: String, id: int):
 	character_id = id
 	$CharacterName.text = name
 
+func set_portrait(texture: Texture2D):
+	$Portrait.texture = texture
 func _show_context_menu():
 	var pm = $PopupMenu
 	pm.position = get_local_mouse_position()
@@ -66,3 +70,4 @@ func _on_popup_menu_id_pressed(id: int):
 		0: print("Inspect ", character_name)
 		1: emit_signal("rename_requested", self)
 		2: emit_signal("remove_connections", self)
+                3: emit_signal("request_portrait", self)


### PR DESCRIPTION
## Summary
- add PortraitFileDialog to board scene
- connect new file dialog and request_portrait signal in `board.gd`
- add portrait handling signals and menu item to character cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c120039008329bf5a408a1eda9da5